### PR TITLE
feat: 省略可能な母音と複数母音マッチを扱えるようにする

### DIFF
--- a/rhyme.py
+++ b/rhyme.py
@@ -31,18 +31,51 @@ class WordInfo:
         i = 0
         while i < len(hira):
             char = hira[i]
-            if char == 'ー' and result:
-                result.append(result[-1])
+            vowel = None
+
+            if char == 'ー':
+                if result:
+                    last_vowel_info = result[-1]
+                    last_vowel = last_vowel_info[0] if isinstance(last_vowel_info, list) else last_vowel_info
+                    result.append([last_vowel, 'optional'])
                 i += 1
-            elif i + 1 < len(hira) and hira[i+1] in small_vowels:
-                result.append(small_vowels[hira[i+1]])
+                continue
+
+            if char == 'っ':
+                if result:
+                    last_vowel_info = result[-1]
+                    last_vowel = last_vowel_info[0] if isinstance(last_vowel_info, list) else last_vowel_info
+                    result.append([last_vowel, 'っ', 'optional'])
+                else:
+                    result.append(['っ', 'optional'])
+                i += 1
+                continue
+
+            if char == 'ん':
+                result.append(['ん', 'う', 'optional'])
+                i += 1
+                continue
+
+            if i + 1 < len(hira) and hira[i+1] in small_vowels:
+                vowel = small_vowels[hira[i+1]]
                 i += 2
             elif char in hiragana_vowels:
-                result.append(hiragana_vowels[char])
+                vowel = hiragana_vowels[char]
                 i += 1
             else:
                 i += 1
-        return "".join(result)
+                continue
+
+            if result:
+                last_vowel_info = result[-1]
+                last_vowel = last_vowel_info[0] if isinstance(last_vowel_info, list) else last_vowel_info
+                if vowel == last_vowel:
+                    result.append([vowel, 'optional'])
+                else:
+                    result.append(vowel)
+            else:
+                result.append(vowel)
+        return result
 
     def _update_vowels(self):
         result = self.kks.convert(self.word)

--- a/rhyme.py
+++ b/rhyme.py
@@ -1,4 +1,3 @@
-
 from pykakasi import kakasi
 
 class WordInfo:
@@ -36,16 +35,34 @@ class WordInfo:
             if char == 'ー':
                 if result:
                     last_vowel_info = result[-1]
-                    last_vowel = last_vowel_info[0] if isinstance(last_vowel_info, list) else last_vowel_info
-                    result.append([last_vowel, 'optional'])
+                    
+                    last_vowels = []
+                    if isinstance(last_vowel_info, list):
+                        for item in last_vowel_info:
+                            if item not in ['optional', 'っ']:
+                                last_vowels.append(item)
+                    else:
+                        last_vowels.append(last_vowel_info)
+
+                    if last_vowels:
+                        result.append([last_vowels[-1], 'optional'])
                 i += 1
                 continue
 
             if char == 'っ':
                 if result:
                     last_vowel_info = result[-1]
-                    last_vowel = last_vowel_info[0] if isinstance(last_vowel_info, list) else last_vowel_info
-                    result.append([last_vowel, 'っ', 'optional'])
+
+                    last_vowels = []
+                    if isinstance(last_vowel_info, list):
+                        for item in last_vowel_info:
+                            if item not in ['optional', 'っ']:
+                                last_vowels.append(item)
+                    else:
+                        last_vowels.append(last_vowel_info)
+                        
+                    if last_vowels:
+                        result.append([last_vowels[-1], 'っ', 'optional'])
                 else:
                     result.append(['っ', 'optional'])
                 i += 1
@@ -68,8 +85,18 @@ class WordInfo:
 
             if result:
                 last_vowel_info = result[-1]
-                last_vowel = last_vowel_info[0] if isinstance(last_vowel_info, list) else last_vowel_info
-                if vowel == last_vowel:
+                
+                last_vowels = []
+                if isinstance(last_vowel_info, list):
+                    for item in last_vowel_info:
+                        if item not in ['optional', 'っ']:
+                            last_vowels.append(item)
+                else:
+                    last_vowels.append(last_vowel_info)
+
+                is_vowel_char = char in ['あ', 'い', 'う', 'え', 'お']
+
+                if vowel in last_vowels and (is_vowel_char or len(last_vowels) == 1):
                     result.append([vowel, 'optional'])
                 else:
                     result.append(vowel)

--- a/rhyme.py
+++ b/rhyme.py
@@ -45,7 +45,7 @@ class WordInfo:
                         last_vowels.append(last_vowel_info)
 
                     if last_vowels:
-                        result.append([last_vowels[-1], 'optional'])
+                        result.append(last_vowels + ['optional'])
                 i += 1
                 continue
 
@@ -62,7 +62,7 @@ class WordInfo:
                         last_vowels.append(last_vowel_info)
                         
                     if last_vowels:
-                        result.append([last_vowels[-1], 'っ', 'optional'])
+                        result.append(last_vowels + ['っ', 'optional'])
                 else:
                     result.append(['っ', 'optional'])
                 i += 1

--- a/test_rhyme.py
+++ b/test_rhyme.py
@@ -34,5 +34,9 @@ class TestWordInfo(unittest.TestCase):
         word_info = WordInfo("あんうん")
         self.assertEqual(word_info.vowels, ['あ', ['ん', 'う', 'optional'], ['う', 'optional'], ['ん', 'う', 'optional']])
 
+    def test_get_vowels_n_bar(self):
+        word_info = WordInfo("んー")
+        self.assertEqual(word_info.vowels, [['ん', 'う', 'optional'], ['ん', 'う', 'optional']])
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_rhyme.py
+++ b/test_rhyme.py
@@ -4,15 +4,31 @@ from rhyme import WordInfo
 class TestWordInfo(unittest.TestCase):
     def test_get_vowels_hiragana(self):
         word_info = WordInfo("こんにちは")
-        self.assertEqual(word_info.vowels, "おんいいあ")
+        self.assertEqual(word_info.vowels, ['お', ['ん', 'う', 'optional'], 'い', ['い', 'optional'], 'あ'])
 
     def test_get_vowels_kanji(self):
         word_info = WordInfo("日本語")
-        self.assertEqual(word_info.vowels, "いおんお")
+        self.assertEqual(word_info.vowels, ['い', 'お', ['ん', 'う', 'optional'], 'お'])
 
     def test_get_vowels_katakana(self):
         word_info = WordInfo("コンピュータ")
-        self.assertEqual(word_info.vowels, "おんううあ")
+        self.assertEqual(word_info.vowels, ['お', ['ん', 'う', 'optional'], 'う', ['う', 'optional'], 'あ'])
+
+    def test_get_vowels_art(self):
+        word_info = WordInfo("アート")
+        self.assertEqual(word_info.vowels, ['あ', ['あ', 'optional'], 'お'])
+
+    def test_get_vowels_matt(self):
+        word_info = WordInfo("マット")
+        self.assertEqual(word_info.vowels, ['あ', ['あ', 'っ', 'optional'], 'お'])
+
+    def test_get_vowels_bant(self):
+        word_info = WordInfo("バント")
+        self.assertEqual(word_info.vowels, ['あ', ['ん', 'う', 'optional'], 'お'])
+
+    def test_get_vowels_pasokon(self):
+        word_info = WordInfo("パソコン")
+        self.assertEqual(word_info.vowels, ['あ', 'お', ['お', 'optional'], ['ん', 'う', 'optional']])
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_rhyme.py
+++ b/test_rhyme.py
@@ -30,5 +30,9 @@ class TestWordInfo(unittest.TestCase):
         word_info = WordInfo("パソコン")
         self.assertEqual(word_info.vowels, ['あ', 'お', ['お', 'optional'], ['ん', 'う', 'optional']])
 
+    def test_get_vowels_anun(self):
+        word_info = WordInfo("あんうん")
+        self.assertEqual(word_info.vowels, ['あ', ['ん', 'う', 'optional'], ['う', 'optional'], ['ん', 'う', 'optional']])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 概要
`rhyme.py`で単語の母音を取得する際に、省略可能な母音と複数の母音にマッチする韻の情報を扱えるようにしました。
## 関連Issue
Closes #8

 ## 変更内容
 - `rhyme.py`の`_get_vowels_from_hiragana`メソッドを修正し、母音の情報を文字列ではなくリストで返すように変更しました。
- これにより、以下のような詳細な母音情報を表現できます。
- 連続する母音: `['あ', ['あ', 'optional'], 'お']`
- 促音「っ」: `['あ', ['あ', 'っ', 'optional'], 'お']`
- 撥音「ん」: `['あ', ['ん', 'う', 'optional'], 'お']`
## テスト
`test_rhyme.py`のテストケースを、新しい母音情報の仕様に合わせて更新しました。
`python -m unittest test_rhyme.py` を実行し、すべてのテストがパスすることを確認済みです。
## その他
- `ruff check .` を実行し、Lintエラーがないことを確認済みです。